### PR TITLE
Compatibility with Lua 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ core.*
 local/
 src/TODO
 src/DIFF
+*.*~
+build64

--- a/src/compat-5.3.h
+++ b/src/compat-5.3.h
@@ -399,12 +399,13 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
+//@@ #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 504
 //@@ #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 503
 
-#  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, or 5.3)"
+#error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, 5.4, or 5.5)"
 
-#endif /* other Lua versions except 5.1, 5.2, and 5.3 */
+#endif /* other Lua versions except 5.1, 5.2, 5.3, 5.4, and 5.5 */
 
 
 


### PR DESCRIPTION
Made minor tweaks to `src/compat-5.3.h` to ensure `moonusb` is compatible with Lua 5.5, along with adding some `.gitignore` entries handy for the Windows environment.